### PR TITLE
only wake up when mpd is playing and not on other mpd events

### DIFF
--- a/kunst
+++ b/kunst
@@ -218,7 +218,9 @@ main() {
 
 		# Waiting for an event from mpd; play/pause/next/previous
 		# this is lets kunst use less CPU :)
-		mpc idle &> /dev/null
+		while true; do
+		    mpc idle player &>/dev/null && (mpc status | grep "\[playing\]" &>/dev/null) && break
+		done
         if [ ! $SILENT ];then
             echo "kunst: received event from mpd"
         fi


### PR DESCRIPTION
This prevents kunst from waking up by irrelevant events, such as volume changes and pausing. It should only wake up when the song changes or when a song is resumed after pausing.
```diff
--- a/kunst
+++ b/kunst
@@ -218,7 +218,9 @@ main() {

                # Waiting for an event from mpd; play/pause/next/previous
                # this is lets kunst use less CPU :)
-               mpc idle &> /dev/null
+               while true; do
+                   mpc idle player &>/dev/null && (mpc status | grep "\[playing\]" &>/dev/null) && break
+               done
         if [ ! $SILENT ];then
             echo "kunst: received event from mpd"
         fi
```