### PR TITLE
Chore: format using `shfmt`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,10 +3,12 @@ root = true
 # Unix-style newlines with a newline ending every file
 [*]
 end_of_line = lf
-insert_final_newline = true
+insert_final_newline = false
 charset = utf-8
 indent_style = tab
 indent_size = 4
+binary_next_line   = true
+switch_case_indent = true
 
 # Tab indentation (no size specified)
 [*.md]

--- a/kunst
+++ b/kunst
@@ -6,14 +6,12 @@
 #
 # Dependencies: sxiv or imv, bash, ffmpeg, mpc, jq, mpd
 
-
 VERSION=1.2.5
 COVER=/tmp/kunst.jpg
 MUSIC_DIR=~/Music/
 WIDTH=250
 SIZE="${WIDTH}x${WIDTH}"
 POSITION="+0+0"
-
 
 show_help() {
 	echo "usage: kunst [-h] [--size "px"] [--position "+x+y"] [--viewer <imv|x11>] [--music_dir "path/to/dir"] [--silent] [--version]"
@@ -26,53 +24,52 @@ show_help() {
 	echo "optional arguments:"
 	echo "   -h, --help            show this help message and exit"
 	echo "   --size                what size to display the album art in"
-  echo "   --position            the position where the album art should be displayed"
+	echo "   --position            the position where the album art should be displayed"
 	echo "   --viewer              whether to use imv or sxiv"
 	echo "   --music_dir           the music directory which MPD plays from"
 	echo "   --silent              dont show the output"
 	echo "   --version             show the version of kunst you are using"
 }
 
-
 # Parse the arguments
 options=$(getopt -o h --long position:,size:,music_dir:,version,silent,help -- "$@")
 eval set -- "$options"
 
 while true; do
-    case "$1" in 
-        --size)
-            shift;
-            SIZE=$1
-            ;;
-        --position)
-            shift;
-            POSITION=$1
-            ;;
-				--viewer)
-					shift;
-					VIEWER=$1
-					;;
-        --music_dir)
-            shift;
-            MUSIC_DIR=$1
-            ;;
-        -h|--help)
-		    show_help
-			exit
-            ;;
-		--version)
-		    echo $VERSION
+	case "$1" in
+		--size)
+			shift
+			SIZE=$1
+			;;
+		--position)
+			shift
+			POSITION=$1
+			;;
+		--viewer)
+			shift
+			VIEWER=$1
+			;;
+		--music_dir)
+			shift
+			MUSIC_DIR=$1
+			;;
+		-h | --help)
+			show_help
 			exit
 			;;
-        --silent)
-            SILENT=true
-            ;;
-        --)
-            shift
-            break
-            ;;
-    esac
-    shift
+		--version)
+			echo $VERSION
+			exit
+			;;
+		--silent)
+			SILENT=true
+			;;
+		--)
+			shift
+			break
+			;;
+	esac
+	shift
 done
 
 # If available, use imv instead of sxiv on Wayland,
@@ -85,31 +82,29 @@ fi
 # This is a base64 endcoded image which will be used if
 # the file does not have an emmbeded album art.
 # The image is an image of a music note
-read -d '' MUSIC_NOTE << EOF
+read -d '' MUSIC_NOTE <<EOF
 iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAJESURBVGhD7Zg/axRRFMVXAtpYphEVREKClnHfJI0MmReSfAC3tRejhaBgo70fwN7aD2BvEU0gfztbu5AqMxNjoVnvG87KZXy7z5m5dxLI/OCw8Pade+7M3n3Dbq+jo6OjY8RwMJhKk+hhlph3eRJ9w/LF5jCOr1PTj6jpD7mNjkjDkbDl4vFjpX87teZJlkSfSD9501zYfv5QJ1fyZHGexuJtZs12ZqMzX8NlwX4+nK3NXMutWaOm39Nd/u5rMCSUao80fjBNwY+p8Y+krNxQVaGsLsfWzFLYS2r4M30Rf5WbaCJE6OILlhIidPEFSwkRuviCpYQIXXzB1WX26bR6ky4v3OPriNCFB1YRHa079Pr6eKk/h1IFfA+WdOGBk+QeXtT0Ft3pV6e2fxf2f+AeLOnCA8tC0xv09H1xGi/cgWUi3I8lXXigEzX8u3gmWPP8JI5uYdt/w2thSRceSM0/zVfnb+CtWvB6WNJFOlC6XhDpQOl6QaQDpesFkQ6UrhdEOlC6XpA6gcPB/avumKXnxCadXHkha766tTr1GlE18CRZvEmN7nHfOMGiS5XA4mdmYg64Z5Jg06VKYHlEQoKtOVIz6zx8f0iwNUNyZt2F+3zjBFt9pGe22gWYFLb6lEckJNjGUmWEssR8ga0+0jNL9Z75fD7Rp7UOW32kZxb/1u37vFyUu+sODtjqozGzxaFADfprFM3vuD3Y3gytmf17LJPHXbgTNb5BWhe58yNan1lpWp9ZDVqdWS1am9mOjo7LRq/3B1ESKyYUVquzAAAAAElFTkSuQmCC
 EOF
 
-
 is_connected() {
 	# Check if internet is connected. We are using api.deezer.com to test
-	# if the internet is connected because if api.deezer.com is down or 
+	# if the internet is connected because if api.deezer.com is down or
 	# the internet is not connected this script will work as expected
 	if ping -q -c 1 -W 1 api.deezer.com >/dev/null; then
 		connected=true
 	else
-        if [ ! $SILENT ];then
-            echo "kunst: unable to check online for the album art"
-        fi
+		if [ ! $SILENT ]; then
+			echo "kunst: unable to check online for the album art"
+		fi
 		connected=false
 	fi
 }
-
 
 get_cover_online() {
 	# Check if connected to internet
 	is_connected
 
-	if [ $connected == false ];then
+	if [ $connected == false ]; then
 		ARTLESS=true
 		return
 	fi
@@ -120,21 +115,20 @@ get_cover_online() {
 	# Extract the albumcover from the json returned
 	IMG_URL=$(curl -s --ssl "$API_URL" | jq -r '.playlists.data[0] | .picture_big')
 
-	if [ "$IMG_URL" = '' ] || [ "$IMG_URL" = 'null' ];then
-        if [ ! $SILENT ];then
-            echo "error: cover not found online"
-        fi
+	if [ "$IMG_URL" = '' ] || [ "$IMG_URL" = 'null' ]; then
+		if [ ! $SILENT ]; then
+			echo "error: cover not found online"
+		fi
 		ARTLESS=true
 	else
-        if [ ! $SILENT ];then
-            echo "kunst: cover found online"
-        fi
+		if [ ! $SILENT ]; then
+			echo "kunst: cover found online"
+		fi
 		curl -o $COVER -s --ssl $IMG_URL
 		ARTLESS=false
 	fi
 
 }
-
 
 update_cover() {
 	# Extract the album art from the mp3 file and dont show the messsy
@@ -145,16 +139,16 @@ update_cover() {
 	STATUS=$?
 
 	# Check if the file has a embbeded album art
-	if [ $STATUS -eq 0 ];then
-        if [ ! $SILENT ];then 
-            echo "kunst: extracted album art"
-        fi
+	if [ $STATUS -eq 0 ]; then
+		if [ ! $SILENT ]; then
+			echo "kunst: extracted album art"
+		fi
 		ARTLESS=false
 	else
-        DIR="$MUSIC_DIR/$(dirname "$(mpc current -f %file%)")"
-        if [ ! $SILENT ];then
-            echo "kunst: inspecting $DIR"
-        fi
+		DIR="$MUSIC_DIR/$(dirname "$(mpc current -f %file%)")"
+		if [ ! $SILENT ]; then
+			echo "kunst: inspecting $DIR"
+		fi
 
 		# Check if there is an album cover/art in the folder.
 		# Look at issue #9 for more details
@@ -163,51 +157,51 @@ update_cover() {
 			find "$DIR" -type f \
 				| grep -iE '/(([0-9| |-]*)?)(album|cover|\.?folder|front).*\.(gif|jpeg|jpg|png)$'
 		)
-          while read -r CANDIDATE; do
-            if [ -f "$CANDIDATE" ]; then
-                STATUS=0
-                ARTLESS=false
-                ffmpeg -loglevel error -i "$CANDIDATE" -vframes 1 $COVER -y
-                if [ ! $SILENT ];then
-                    echo "kunst: found cover $CANDIDATE"
-                fi
-								break
-            fi
-        done <<< "$candidates" # use here string so loop changes vars in main process
-    fi
+		while read -r CANDIDATE; do
+			if [ -f "$CANDIDATE" ]; then
+				STATUS=0
+				ARTLESS=false
+				ffmpeg -loglevel error -i "$CANDIDATE" -vframes 1 $COVER -y
+				if [ ! $SILENT ]; then
+					echo "kunst: found cover $CANDIDATE"
+				fi
+				break
+			fi
+		done <<<"$candidates" # use here string so loop changes vars in main process
+	fi
 
-	if [ $STATUS -ne 0 ];then
-        if [ ! $SILENT ];then
-            echo "error: file does not have an album art"
-        fi
+	if [ $STATUS -ne 0 ]; then
+		if [ ! $SILENT ]; then
+			echo "error: file does not have an album art"
+		fi
 		get_cover_online
 	fi
 
 	# Resize the image to 250x250
 	if [ $ARTLESS == false ]; then
 		ffmpeg -loglevel error -i $COVER -vframes 1 -vf scale=$WIDTH:-1 $COVER -y
-        if [ ! $SILENT ];then
-            echo "kunst: resized album art to $SIZE"
-        fi
+		if [ ! $SILENT ]; then
+			echo "kunst: resized album art to $SIZE"
+		fi
 	fi
 
 }
 
 pre_exit() {
 	# Get the proccess ID of kunst and kill it.
-    # We are dumping the output of kill to /dev/null
-    # because if the user quits the image viewer
-		# before they exit kunst, an error will be shown
-    # from kill and we dont want that
-	kill -9 $(cat /tmp/kunst.pid) &> /dev/null
- 
+	# We are dumping the output of kill to /dev/null
+	# because if the user quits the image viewer
+	# before they exit kunst, an error will be shown
+	# from kill and we dont want that
+	kill -9 $(cat /tmp/kunst.pid) &>/dev/null
+
 }
 
 main() {
-    
-    [[ $KUNST_MUSIC_DIR != "" ]] && MUSIC_DIR=$KUNST_MUSIC_DIR
-    [[ $KUNST_SIZE != "" ]] && SIZE=$KUNST_SIZE
-    [[ $KUNST_POSITION != "" ]] && POSITION=$KUNST_POSITION
+
+	[[ $KUNST_MUSIC_DIR != "" ]] && MUSIC_DIR=$KUNST_MUSIC_DIR
+	[[ $KUNST_SIZE != "" ]] && SIZE=$KUNST_SIZE
+	[[ $KUNST_POSITION != "" ]] && POSITION=$KUNST_POSITION
 
 	# Flag to run some commands only once in the loop
 	FIRST_RUN=true
@@ -216,20 +210,20 @@ main() {
 
 		update_cover
 
-		if [ $ARTLESS == true ];then
+		if [ $ARTLESS == true ]; then
 			# Dhange the path to COVER because the music note
 			# image is a png not jpg
 			COVER=/tmp/kunst.png
 
 			# Decode the base64 encoded image and save it
 			# to /tmp/kunst.png
-			echo "$MUSIC_NOTE" | base64 --decode > $COVER
+			echo "$MUSIC_NOTE" | base64 --decode >$COVER
 		fi
-        
-        if [ ! $SILENT ];then
-            echo "kunst: swapped album art to $(mpc current)"
-            printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
-        fi
+
+		if [ ! $SILENT ]; then
+			echo "kunst: swapped album art to $(mpc current)"
+			printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
+		fi
 
 		if [ $FIRST_RUN == true ]; then
 			FIRST_RUN=false
@@ -251,11 +245,11 @@ main() {
 		# Waiting for an event from mpd; play/pause/next/previous
 		# this is lets kunst use less CPU :)
 		while true; do
-		    mpc idle player &>/dev/null && (mpc status | grep "\[playing\]" &>/dev/null) && break
+			mpc idle player &>/dev/null && (mpc status | grep "\[playing\]" &>/dev/null) && break
 		done
-        if [ ! $SILENT ];then
-            echo "kunst: received event from mpd"
-        fi
+		if [ ! $SILENT ]; then
+			echo "kunst: received event from mpd"
+		fi
 		if [ "$VIEWER" = 'imv' ]; then
 			imv-msg "$(cat /tmp/kunst.pid)" close all
 			imv-msg "$(cat /tmp/kunst.pid)" open "$COVER"


### PR DESCRIPTION
Use [`shfmt`](https://github.com/mvdan/sh) to format kunst. Fixes the
remaining issues in #14.

No flags/customizations are needed; all have been added to
.editorconfig.