### PR TITLE
Fixed problematic characters in mpc status output

### DIFF
--- a/kunst
+++ b/kunst
@@ -29,7 +29,7 @@ optional arguments:
    --position            the position where the album art should be displayed
    --music_dir           the music directory which MPD plays from
    --silent              dont show the output
-   --force-online        force getting cover from the internet 
+   --force-online        force getting cover from the internet
    --version             show the version of kunst you are using
 "
 }
@@ -40,7 +40,7 @@ options=$(getopt -o h --long position:,size:,music_dir:,version,force-online,sil
 eval set -- "$options"
 
 while true; do
-    case "$1" in 
+    case "$1" in
         --size)
             shift;
             SIZE=$1
@@ -85,7 +85,7 @@ EOF
 
 is_connected() {
 	# Check if internet is connected. We are using api.deezer.com to test
-	# if the internet is connected because if api.deezer.com is down or 
+	# if the internet is connected because if api.deezer.com is down or
 	# the internet is not connected this script will work as expected
 	if ping -q -c 1 -W 1 api.deezer.com >/dev/null; then
 		connected=true
@@ -108,7 +108,7 @@ get_cover_online() {
     # If the current playing song ends with .mp3 or something similar, remove
     # it before searching for the album art because including the file extension
     # reduces the chance of good results in the search query
-    QUERY=$(mpc current | sed 's/\.[^.]*$//')
+    QUERY=$(mpc current | sed 's/\.[^.]*$//' | iconv -t ascii//TRANSLIT -f utf8)
 
 	# Try to get the album cover online from api.deezer.com
 	API_URL="https://api.deezer.com/search/autocomplete?q=$QUERY" && API_URL=${API_URL//' '/'%20'}
@@ -187,7 +187,7 @@ pre_exit() {
     # exit kunst, an error will be shown
     # from kill and we dont want that
 	kill -9 "$(cat /tmp/kunst.pid)" &>/dev/null
- 
+
 }
 
 main() {
@@ -219,7 +219,7 @@ main() {
 			# to /tmp/kunst.png
 			echo "$MUSIC_NOTE" | base64 --decode > "$COVER"
 		fi
-        
+
         if [ ! "$SILENT" ];then
             echo "kunst: swapped album art to $(mpc current)"
             printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
@@ -230,7 +230,7 @@ main() {
 
 			# Display the album art using sxiv
 			sxiv -g "$SIZE$POSITION" -b "$COVER" -N "Kunst" &
-			
+
 			# Save the process ID so that we can kill
 			# sxiv when the user exits the script
 			echo $! >/tmp/kunst.pid


### PR DESCRIPTION
Fixes #40

I also removed trailing whitespace; hope that's ok