### PR TITLE
Recognize more cover art names and allow user configuration

### DIFF
--- a/kunst
+++ b/kunst
@@ -151,16 +151,19 @@ find_album_art(){
         DIR="$MUSIC_DIR$(dirname "$(mpc current -f %file%)")"
         [ ! "$SILENT" ] && echo "kunst: inspecting $DIR"
 
-		# Check if there is an album cover/art in the folder.
-		# Look at issue #9 for more details
-        for CANDIDATE in "$DIR/cover."{png,jpg}; do
+        COVER_NAMES=${KUNST_COVER_NAMES:-'folder|cover|front'}
+        COVER_EXT=${KUNST_COVER_EXT:-'jpg|png'}
+
+        # Check if there is an album cover/art in the folder.
+        # Look at issues #9 and #45 for more details
+        while IFS= read -r CANDIDATE; do
             if [ -f "$CANDIDATE" ]; then
                 STATUS=0
                 ARTLESS=false
                 convert "$CANDIDATE" $COVER &> /dev/null
-                [ ! "$SILENT" ] && echo "kunst: found cover.png"
+                [ ! "$SILENT" ] && echo "kunst: found $(basename "$CANDIDATE")"
             fi
-        done
+        done < <(find "$DIR" -type f | grep -i -E -- "($COVER_NAMES).($COVER_EXT)")
     fi
 
 	if [ "$STATUS" -ne 0 ];then


### PR DESCRIPTION
Fixes #45 

Uses `find` and `grep` instead of for loop to make it easier to dynamically add patterns to recognize. 

Files in the directory are not all iterated, but rather a list is created once by find and matching files are identified by one grep command, so there should be no performance impact for larger directories.