### PR TITLE
Add option to save the cover art fetched from the internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="extra/kunst_logo.png"><br><sub>✨ Download and display album art or display embedded album art  ✨</sub></p>
 
-```kunst``` is a daemon that extracts the album art from the songs playing in ```mpd``` and displays them in the a little window. It doesn't loop on a timer, instead it waits for ```mpd``` to send a ```player``` event. When it receives a ```player``` event, it wakes up and extracts the album art of the current playing track. This makes ```kunst```really lightweight and makes it idle at ```~0%``` CPU usage. If there no embbeded album art, it will try to fetch the album art from the internet.
+```kunst``` is a daemon that extracts the album art from the songs playing in ```mpd``` and displays them in a little window. It doesn't loop on a timer, instead it waits for ```mpd``` to send a ```player``` event. When it receives a ```player``` event, it wakes up and extracts the album art of the current playing track. This makes ```kunst```really lightweight and makes it idle at ```~0%``` CPU usage. If there no embbeded album art, it will try to fetch the album art from the internet.
 
 
 <p align="left">
@@ -54,6 +54,8 @@ optional arguments:
    --position            the position where the album art should be displayed
    --music_dir           the music directory which MPD plays from
    --silent              dont show the output
+   --force-online        force getting cover from the internet
+   --save-cover          save downloaded cover art to your music directory so you won't have to fetch it from the internet again
    --version             show the version of kunst you are using
 ```
 

--- a/kunst
+++ b/kunst
@@ -13,6 +13,7 @@ MUSIC_DIR=~/Music/
 SIZE=250x250
 POSITION="+0+0"
 ONLINE_ALBUM_ART=false
+SAVE_DOWNLOADED_COVER=false
 
 show_help() {
 printf "%s" "\
@@ -30,13 +31,14 @@ optional arguments:
    --music_dir           the music directory which MPD plays from
    --silent              dont show the output
    --force-online        force getting cover from the internet
+   --save-cover          save downloaded cover art to your music directory so you won't have to fetch it from the internet again
    --version             show the version of kunst you are using
 "
 }
 
 
 # Parse the arguments
-options=$(getopt -o h --long position:,size:,music_dir:,version,force-online,silent,help -- "$@")
+options=$(getopt -o h --long position:,size:,music_dir:,version,force-online,silent,save-cover,help -- "$@")
 eval set -- "$options"
 
 while true; do
@@ -66,6 +68,9 @@ while true; do
             ;;
         --silent)
             SILENT=true
+            ;;
+        --save-cover)
+            SAVE_DOWNLOADED_COVER=true
             ;;
         --)
             shift
@@ -123,6 +128,11 @@ get_cover_online() {
         [ ! "$SILENT" ] && echo "kunst: cover found online"
 		curl -o "$COVER" -s "$IMG_URL"
 		ARTLESS=false
+		if [ "$SAVE_DOWNLOADED_COVER" == true ];then
+			COVER_PATH="$MUSIC_DIR$(dirname "$(mpc current -f %file%)")/cover.png"
+			[ ! "$SILENT" ] && echo "kunst: saving downloaded cover to $COVER_PATH"
+			convert "$COVER" $COVER_PATH &> /dev/null
+		fi
 	fi
 
 }


### PR DESCRIPTION
As kunst is triggered on every song change, if you're listening to an album that you don't have the artwork saved for you end up fetching it online for each track.

I've added a new option to set when running kunst to save the downloaded `cover.png` file to the album directory meaning it will only be downloaded the first time, as the next tracks played from the album will be able to find the local file.

Example of it running fetching the cover art for the first track, but then using the existing cover art for the next tracks played from the same album:
![Screenshot from 2020-11-17 17-15-51](https://user-images.githubusercontent.com/14163530/99441733-375d2980-2910-11eb-8971-1961e24f66a6.png)
