### PR TITLE
Fixed typo

### DIFF
--- a/kunst
+++ b/kunst
@@ -9,7 +9,7 @@
 
 VERSION=1.3.2
 COVER=/tmp/kunst.jpg
-MUSIC_DIR=~/Music/
+MUSIC_DIR=~/Music
 SIZE=250x250
 POSITION="+0+0"
 ONLINE_ALBUM_ART=false


### PR DESCRIPTION
The file was displaying as ~/Music//.../artist/album ; removing this slash will have it display properly with only one / at the end of the directory name.