### PR TITLE
Add option for MPD host address, defaults to "127.0.0.1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ optional arguments:
    --size                what size to display the album art in
    --position            the position where the album art should be displayed
    --music_dir           the music directory which MPD plays from
+   --host                address MPD is bound to
    --silent              dont show the output
    --version             show the version of kunst you are using
 ```
@@ -70,6 +71,9 @@ export KUNST_POSITION="+0+0"
 
 # Where your music is located
 export KUNST_MUSIC_DIR="/home/username/Music/"
+
+# MPD host address
+export KUNST_MPD_HOST="127.0.0.2"
 ```
 
 <p align="center">

--- a/kunst
+++ b/kunst
@@ -10,13 +10,14 @@
 VERSION=1.3.2
 COVER=/tmp/kunst.jpg
 MUSIC_DIR=~/Music
+MPD_HOST=127.0.0.1
 SIZE=250x250
 POSITION="+0+0"
 ONLINE_ALBUM_ART=false
 
 show_help() {
 printf "%s" "\
-usage: kunst [-h] [--size \"px\"] [--position \"+x+y\"][--music_dir \"path/to/dir\"] [--silent] [--version]
+usage: kunst [-h] [--size \"px\"] [--position \"+x+y\"][--music_dir \"path/to/dir\"] [--host \"127.0.0.1\"] [--silent] [--version]
 
 ┬┌─┬ ┬┌┐┌┌─┐┌┬┐
 ├┴┐│ ││││└─┐ │
@@ -28,6 +29,7 @@ optional arguments:
    --size                what size to display the album art in
    --position            the position where the album art should be displayed
    --music_dir           the music directory which MPD plays from
+   --host                address MPD is bound to
    --silent              dont show the output
    --force-online        force getting cover from the internet
    --version             show the version of kunst you are using
@@ -36,7 +38,7 @@ optional arguments:
 
 
 # Parse the arguments
-options=$(getopt -o h --long position:,size:,music_dir:,version,force-online,silent,help -- "$@")
+options=$(getopt -o h --long position:,size:,music_dir:,host:,version,force-online,silent,help -- "$@")
 eval set -- "$options"
 
 while true; do
@@ -52,6 +54,10 @@ while true; do
         --music_dir)
             shift;
             MUSIC_DIR=$1
+            ;;
+        --host)
+            shift;
+            MPD_HOST=$1
             ;;
         -h|--help)
 		    show_help
@@ -108,7 +114,7 @@ get_cover_online() {
     # If the current playing song ends with .mp3 or something similar, remove
     # it before searching for the album art because including the file extension
     # reduces the chance of good results in the search query
-    QUERY=$(mpc current | sed 's/\.[^.]*$//' | iconv -t ascii//TRANSLIT -f utf8)
+    QUERY=$(mpc current --host "$MPD_HOST" | sed 's/\.[^.]*$//' | iconv -t ascii//TRANSLIT -f utf8)
 
 	# Try to get the album cover online from api.deezer.com
 	API_URL="https://api.deezer.com/search/autocomplete?q=$QUERY" && API_URL=${API_URL//' '/'%20'}
@@ -138,7 +144,7 @@ find_album_art(){
 
 	# Extract the album art from the mp3 file and dont show the messsy
 	# output of ffmpeg
-	ffmpeg -i "$MUSIC_DIR$(mpc current -f %file%)" "$COVER" -y &> /dev/null
+	ffmpeg -i "$MUSIC_DIR$(mpc current --host $MPD_HOST -f %file%)" "$COVER" -y &> /dev/null
 
 	# Get the status of the previous command
 	STATUS=$?
@@ -148,7 +154,7 @@ find_album_art(){
         [ ! "$SILENT" ] && echo "kunst: extracted album art"
 		ARTLESS=false
 	else
-        DIR="$MUSIC_DIR$(dirname "$(mpc current -f %file%)")"
+        DIR="$MUSIC_DIR$(dirname "$(mpc current --host $MPD_HOST -f %file%)")"
         [ ! "$SILENT" ] && echo "kunst: inspecting $DIR"
 
 		# Check if there is an album cover/art in the folder.
@@ -203,6 +209,7 @@ main() {
     [ "$KUNST_MUSIC_DIR" != "" ] && MUSIC_DIR="$KUNST_MUSIC_DIR"
     [ "$KUNST_SIZE" != "" ] && SIZE="$KUNST_SIZE"
     [ "$KUNST_POSITION" != "" ] && POSITION="$KUNST_POSITION"
+    [ "$KUNST_MPD_HOST" != "" ] && MPD_HOST="$KUNST_MPD_HOST"
 
 	# Flag to run some commands only once in the loop
 	FIRST_RUN=true
@@ -221,7 +228,7 @@ main() {
 		fi
 
         if [ ! "$SILENT" ];then
-            echo "kunst: swapped album art to $(mpc current)"
+            echo "kunst: swapped album art to $(mpc current --host $MPD_HOST)"
             printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' -
         fi
 
@@ -239,7 +246,7 @@ main() {
 		# Waiting for an event from mpd; play/pause/next/previous
 		# this is lets kunst use less CPU :)
 		while true; do
-		    mpc idle player &>/dev/null && (mpc status | grep "\[playing\]" &>/dev/null) && break
+		    mpc idle player --host "$MPD_HOST" &>/dev/null && (mpc status --host "$MPD_HOST" | grep "\[playing\]" &>/dev/null) && break
 		done
         [ ! "$SILENT" ] && echo "kunst: received event from mpd"
 	done


### PR DESCRIPTION
I run MPD on the address `127.0.0.2` instead of the default `127.0.0.1`/localhost. I was not able to use kunst, as it failed with `mpd: connection refused`. I added a new command-line option "host", that can be supplied with the environment variable `$KUNST_MPD_HOST`. I changed every `mpc` command in the script, and updated the usage message and Readme. With this change I can now use kunst.