### PR TITLE
Fix --verbose not working

### DIFF
--- a/kunst
+++ b/kunst
@@ -76,7 +76,7 @@ while true; do
             ONLINE_ALBUM_ART=true
             ;;
         --verbose)
-            verbose=true
+            VERBOSE=true
             ;;
         --)
             shift


### PR DESCRIPTION
The variable that got set was not the same that is being checked in method log.
I changed the casing for it to match.