### PR TITLE
fix: Use `TMPDIR` before defaulting to `/tmp`

### DIFF
--- a/kunst
+++ b/kunst
@@ -8,7 +8,8 @@
 
 
 VERSION=1.3.4
-COVER=/tmp/kunst.jpg
+TMP=${TMPDIR:-/tmp}
+COVER=$TMP/kunst.jpg
 MUSIC_DIR="${KUNST_MUSIC_DIR:-~/Music}"
 SIZE="${KUNST_SIZE:-250x250}"
 POSITION="${KUNST_POSITION:-+0+0}"
@@ -200,7 +201,7 @@ pre_exit() {
     # because if the user quits nsxiv before they
     # exit kunst, an error will be shown
     # from kill and we dont want that
-    kill -9 "$(cat /tmp/kunst.pid)" &>/dev/null
+    kill -9 "$(cat "$TMP/kunst.pid")" &>/dev/null
 
 }
 
@@ -222,7 +223,7 @@ main() {
         if [ "$ARTLESS" == true ];then
             # Dhange the path to COVER because the music note
             # image is a png not jpg
-            COVER=/tmp/kunst.png
+            COVER=$TMP/kunst.png
 
             # Decode the base64 encoded image and save it
             # to /tmp/kunst.png
@@ -239,7 +240,7 @@ main() {
 
             # Save the process ID so that we can kill
             # nsxiv when the user exits the script
-            echo $! >/tmp/kunst.pid
+            echo $! >"$TMP/kunst.pid"
         fi
 
         # Waiting for an event from mpd; play/pause/next/previous


### PR DESCRIPTION
This fixes bugs in which user specifically sets a `TMPDIR`, but this script does not respect it.